### PR TITLE
自動更新機能実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function() {
 
   function buildHTML(message){
     if (message.image) {
-      var html =`<div class="message">
+      var html =`<div class="message" data-message-id="${message.id}">
                   <div class="message__info">
                     <p class="message__info__user">
                       ${message.user_name}
@@ -18,7 +18,7 @@ $(function() {
               </div>`
       return html;
     } else {
-      var html =`<div class="message">
+      var html =`<div class="message" data-message-id="${message.id}">
                   <div class="message__info">
                     <p class="message__info__user">
                       ${message.user_name}
@@ -60,4 +60,32 @@ $(function() {
       $('.new-message__submit-btn').prop('disabled', false);
     })
   })
+  
+
+  var reloadMessages = function() {
+    var last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'GET',
+      dataType: 'json',
+      data: { id: last_message_id }
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML = insertHTML + buildHTML(message);
+        })
+        $('.chat-main__message-list').append(insertHTML);
+        $('.chat-main__message-list').animate({ scrollTop: $('.chat-main__message-list')[0].scrollHeight});
+      }
+    })
+    .fail(function() {
+      alert('error!');
+    });
+  };
+
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .message__info
     %p.message__info__user
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.content @message.content
 json.image @message.image_url
 json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json'}
+    end
   end
 
 end


### PR DESCRIPTION
# what
APIを使ってメッセージページに自動更新機能を追加
・最新の投稿データを認識できるようメッセージのHTMLに「message-id」とカスタムデータ属性を追加で設定
・API用のmessagesコントローラを作成し自動更新機能用indexアクションを記述(ルーティングも設定済)
・json形式でレスポンスを返すためにindex.json.jbuilderを作成
・message.jsファイルで自動更新アクション呼び出しを受け取ったレスポンスの表示できるよう記述

# why
別ユーザーの投稿をリロード無しに表示させることで、
より実用的なチャットアプリに近づける。<br>

![854ba02d2a2ba7598d6a4e26804b826f](https://user-images.githubusercontent.com/61342566/76695100-5f7bf500-66be-11ea-83a8-5d4028aa675b.gif)